### PR TITLE
[DIRECTMEMORY-43] Cache should allow key objects instead of plain string

### DIFF
--- a/directmemory-cache/src/main/java/org/apache/directmemory/cache/Cache.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/cache/Cache.java
@@ -27,7 +27,7 @@ import org.apache.directmemory.serialization.Serializer;
 public class Cache
 {
 
-    private static CacheService cacheService = new CacheServiceImpl();
+    private static CacheService<String, Object> cacheService = new CacheServiceImpl<String, Object>();
 
     // olamy chicken and eggs isssue
     // private static CacheService cacheService = new CacheServiceImpl( getMemoryManager());
@@ -52,22 +52,22 @@ public class Cache
         init( numberOfBuffers, size, CacheService.DEFAULT_INITIAL_CAPACITY, CacheService.DEFAULT_CONCURRENCY_LEVEL );
     }
 
-    public static Pointer putByteArray( String key, byte[] payload, int expiresIn )
+    public static Pointer<Object> putByteArray( String key, byte[] payload, int expiresIn )
     {
         return cacheService.putByteArray( key, payload, expiresIn );
     }
 
-    public static Pointer putByteArray( String key, byte[] payload )
+    public static Pointer<Object> putByteArray( String key, byte[] payload )
     {
         return cacheService.putByteArray( key, payload );
     }
 
-    public static Pointer put( String key, Object object )
+    public static Pointer<Object> put( String key, Object object )
     {
         return cacheService.put( key, object );
     }
 
-    public static Pointer put( String key, Object object, int expiresIn )
+    public static Pointer<Object> put( String key, Object object, int expiresIn )
     {
         return cacheService.put( key, object, expiresIn );
     }
@@ -82,7 +82,7 @@ public class Cache
         return cacheService.retrieve( key );
     }
 
-    public static Pointer getPointer( String key )
+    public static Pointer<Object> getPointer( String key )
     {
         return cacheService.getPointer( key );
     }
@@ -92,7 +92,7 @@ public class Cache
         cacheService.free( key );
     }
 
-    public static void free( Pointer pointer )
+    public static void free( Pointer<Object> pointer )
     {
         cacheService.free( pointer );
     }
@@ -123,7 +123,7 @@ public class Cache
         return cacheService.entries();
     }
 
-    public static void dump( OffHeapMemoryBuffer mem )
+    public static void dump( OffHeapMemoryBuffer<Object> mem )
     {
         cacheService.dump( mem );
     }
@@ -138,14 +138,14 @@ public class Cache
         return cacheService.getSerializer();
     }
 
-    public static MemoryManagerService getMemoryManager()
+    public static MemoryManagerService<Object> getMemoryManager()
     {
         return cacheService.getMemoryManager();
     }
 
-    public static Pointer allocate( String key, int size )
+    public static Pointer<Object> allocate( String key, int size )
     {
-        return cacheService.allocate( key, size );
+        return cacheService.allocate( key, Object.class, size );
     }
 
 }

--- a/directmemory-cache/src/main/java/org/apache/directmemory/cache/CacheService.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/cache/CacheService.java
@@ -27,7 +27,7 @@ import org.apache.directmemory.serialization.Serializer;
 
 import java.util.concurrent.ConcurrentMap;
 
-public interface CacheService
+public interface CacheService<K, V>
 {
 
     public static int DEFAULT_CONCURRENCY_LEVEL = 4;
@@ -39,23 +39,23 @@ public interface CacheService
 
     void scheduleDisposalEvery( long l );
 
-    Pointer putByteArray( String key, byte[] payload, int expiresIn );
+    Pointer<V> putByteArray( K key, byte[] payload, int expiresIn );
 
-    Pointer putByteArray( String key, byte[] payload );
+    Pointer<V> putByteArray( K key, byte[] payload );
 
-    Pointer put( String key, Object object );
+    Pointer<V> put( K key, V value );
 
-    Pointer put( String key, Object object, int expiresIn );
+    Pointer<V> put( K key, V value, int expiresIn );
 
-    byte[] retrieveByteArray( String key );
+    byte[] retrieveByteArray( K key );
 
-    Object retrieve( String key );
+    Object retrieve( K key );
 
-    Pointer getPointer( String key );
+    Pointer<V> getPointer( K key );
 
-    void free( String key );
+    void free( K key );
 
-    void free( Pointer pointer );
+    void free( Pointer<V> pointer );
 
     void collectExpired();
 
@@ -68,22 +68,22 @@ public interface CacheService
 
     long entries();
 
-    void dump( OffHeapMemoryBuffer mem );
+    void dump( OffHeapMemoryBuffer<V> mem );
 
     void dump();
 
-    ConcurrentMap<String, Pointer> getMap();
+    ConcurrentMap<K, Pointer<V>> getMap();
 
-    void setMap( ConcurrentMap<String, Pointer> map );
+    void setMap( ConcurrentMap<K, Pointer<V>> map );
 
     Serializer getSerializer();
 
-    MemoryManagerService getMemoryManager();
+    MemoryManagerService<V> getMemoryManager();
 
-    void setMemoryManager( MemoryManagerService memoryManager );
+    void setMemoryManager( MemoryManagerService<V> memoryManager );
 
     void setSerializer( Serializer serializer );
 
-    Pointer allocate( String key, int size );
+    <T extends V> Pointer<V> allocate( K key, Class<T> type, int size );
 
 }

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/AllocationPolicy.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/AllocationPolicy.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @author bperroud
  *
  */
-public interface AllocationPolicy
+public interface AllocationPolicy<T>
 {
 
     /**
@@ -38,7 +38,7 @@ public interface AllocationPolicy
      *
      * @param buffers
      */
-    void init( List<OffHeapMemoryBuffer> buffers );
+    void init( List<OffHeapMemoryBuffer<T>> buffers );
 
     /**
      * Returns the active buffer in which to allocate.
@@ -47,7 +47,7 @@ public interface AllocationPolicy
      * @param allocationNumber : the number of time the allocation has already failed.
      * @return the buffer to allocate, or null if allocation has failed.
      */
-    OffHeapMemoryBuffer getActiveBuffer( OffHeapMemoryBuffer previouslyAllocatedBuffer, int allocationNumber );
+    OffHeapMemoryBuffer<T> getActiveBuffer( OffHeapMemoryBuffer<T> previouslyAllocatedBuffer, int allocationNumber );
 
     /**
      * Reset internal state

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManager.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManager.java
@@ -28,7 +28,7 @@ public class MemoryManager
 {
     private static Logger logger = LoggerFactory.getLogger( MemoryManager.class );
 
-    private static MemoryManagerService memoryManager = new MemoryManagerServiceImpl();
+    private static MemoryManagerService<Object> memoryManager = new MemoryManagerServiceImpl<Object>();
 
     private MemoryManager()
     {
@@ -40,27 +40,27 @@ public class MemoryManager
         memoryManager.init( numberOfBuffers, size );
     }
 
-    public static Pointer store( byte[] payload, int expiresIn )
+    public static Pointer<Object> store( byte[] payload, int expiresIn )
     {
         return memoryManager.store( payload, expiresIn );
     }
 
-    public static Pointer store( byte[] payload )
+    public static Pointer<Object> store( byte[] payload )
     {
         return store( payload, 0 );
     }
 
-    public static Pointer update( Pointer pointer, byte[] payload )
+    public static Pointer<Object> update( Pointer<Object> pointer, byte[] payload )
     {
         return memoryManager.update( pointer, payload );
     }
 
-    public static byte[] retrieve( Pointer pointer )
+    public static byte[] retrieve( Pointer<Object> pointer )
     {
         return memoryManager.retrieve( pointer );
     }
 
-    public static void free( Pointer pointer )
+    public static void free( Pointer<Object> pointer )
     {
         memoryManager.free( pointer );
     }
@@ -85,24 +85,24 @@ public class MemoryManager
         memoryManager.collectLFU();
     }
 
-    public static List<OffHeapMemoryBuffer> getBuffers()
+    public static List<OffHeapMemoryBuffer<Object>> getBuffers()
     {
         return memoryManager.getBuffers();
     }
 
 
-    public static OffHeapMemoryBuffer getActiveBuffer()
+    public static OffHeapMemoryBuffer<Object> getActiveBuffer()
     {
         return memoryManager.getActiveBuffer();
     }
 
-    public static MemoryManagerService getMemoryManager()
+    public static MemoryManagerService<Object> getMemoryManager()
     {
         return memoryManager;
     }
 
-    public static Pointer allocate( int size )
+    public static Pointer<Object> allocate( int size )
     {
-        return memoryManager.allocate( size, -1, -1 ); //add a version with expiration
+        return memoryManager.allocate( Object.class, size, -1, -1 ); //add a version with expiration
     }
 }

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManagerService.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManagerService.java
@@ -22,13 +22,13 @@ package org.apache.directmemory.memory;
 
 import java.util.List;
 
-public interface MemoryManagerService
+public interface MemoryManagerService<V>
 {
 
 	/**
 	 * Initialize the internal structure. Need to be called before the service
 	 * can be used.
-	 * 
+	 *
 	 * @param numberOfBuffers
 	 *            : number of internal bucket
 	 * @param size
@@ -36,23 +36,23 @@ public interface MemoryManagerService
 	 */
     void init( int numberOfBuffers, int size );
 
-	
+
 	/**
 	 * Store function family. Store the given payload at a certain offset in a MemoryBuffer, returning the pointer to the value.
-	 * 
+	 *
 	 * @param payload : the data to store
 	 * @return the pointer to the value, or null if not enough space has been found.
 	 */
-    Pointer store( byte[] payload, int expiresIn );
+    Pointer<V> store( byte[] payload, int expiresIn );
 
 	/**
 	 * Same function as {@link #store(byte[])}, but add an relative expiration delta in milliseconds
-	 * 
+	 *
 	 * @param payload : the data to store
 	 * @param expiresIn : relative amount of milliseconds the data will expire
 	 * @return the pointer to the value, or null if not enough space has been found.
 	 */
-    Pointer store( byte[] payload );
+    Pointer<V> store( byte[] payload );
 
 	/**
 	 * Same function as {@link #store(byte[])}, but add an absolute expiration date
@@ -61,22 +61,22 @@ public interface MemoryManagerService
 	 * @return the pointer to the value, or null if not enough space has been found.
 	 */
 	//public Pointer store(byte[] payload, Date expires);
-	
+
 
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * Update value of a {@link Pointer
 	 * @param pointer
 	 * @param payload
 	 * @return
 	 * @throw BufferOverflowException if the size of the payload id bigger than the pointer capacity
 	 */
-    Pointer update(Pointer pointer, byte[] payload);
+    Pointer<V> update(Pointer<V> pointer, byte[] payload);
 
-    byte[] retrieve( Pointer pointer );
+    byte[] retrieve( Pointer<V> pointer );
 
-    void free( Pointer pointer );
+    void free( Pointer<V> pointer );
 
     void clear();
 
@@ -86,10 +86,10 @@ public interface MemoryManagerService
 
     void collectLFU();
 
-    List<OffHeapMemoryBuffer> getBuffers();
+    List<OffHeapMemoryBuffer<V>> getBuffers();
 
-    OffHeapMemoryBuffer getActiveBuffer();
+    OffHeapMemoryBuffer<V> getActiveBuffer();
 
-    Pointer allocate( int size, long expiresIn, long expires );
+    <T extends V> Pointer<V> allocate( Class<T> type, int size, long expiresIn, long expires );
 
 }

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManagerServiceWithAllocationPolicyImpl.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/MemoryManagerServiceWithAllocationPolicyImpl.java
@@ -24,11 +24,11 @@ package org.apache.directmemory.memory;
  *
  * @author bperroud
  */
-public class MemoryManagerServiceWithAllocationPolicyImpl
-    extends MemoryManagerServiceImpl
+public class MemoryManagerServiceWithAllocationPolicyImpl<V>
+    extends MemoryManagerServiceImpl<V>
 {
 
-    protected AllocationPolicy allocationPolicy;
+    protected AllocationPolicy<V> allocationPolicy;
 
     @Override
     public void init( int numberOfBuffers, int size )
@@ -37,22 +37,22 @@ public class MemoryManagerServiceWithAllocationPolicyImpl
         allocationPolicy.init( getBuffers() );
     }
 
-    public void setAllocationPolicy( final AllocationPolicy allocationPolicy )
+    public void setAllocationPolicy( final AllocationPolicy<V> allocationPolicy )
     {
         this.allocationPolicy = allocationPolicy;
     }
 
     @Override
-    public OffHeapMemoryBuffer getActiveBuffer()
+    public OffHeapMemoryBuffer<V> getActiveBuffer()
     {
         return allocationPolicy.getActiveBuffer( null, 0 );
     }
 
     @Override
-    public Pointer store( byte[] payload, int expiresIn )
+    public Pointer<V> store( byte[] payload, int expiresIn )
     {
-        Pointer p = null;
-        OffHeapMemoryBuffer buffer = null;
+        Pointer<V> p = null;
+        OffHeapMemoryBuffer<V> buffer = null;
         int allocationNumber = 1;
         do
         {
@@ -76,10 +76,10 @@ public class MemoryManagerServiceWithAllocationPolicyImpl
     }
 
     @Override
-    public Pointer allocate( int size, long expiresIn, long expires )
+    public <T extends V> Pointer<V> allocate( Class<T> type, int size, long expiresIn, long expires )
     {
-        Pointer p = null;
-        OffHeapMemoryBuffer buffer = null;
+        Pointer<V> p = null;
+        OffHeapMemoryBuffer<V> buffer = null;
         int allocationNumber = 1;
         do
         {
@@ -88,7 +88,7 @@ public class MemoryManagerServiceWithAllocationPolicyImpl
             {
                 return null;
             }
-            p = buffer.allocate( size, expiresIn, expires );
+            p = buffer.allocate( type, size, expiresIn, expires );
             allocationNumber++;
         }
         while ( p == null );

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/OffHeapMemoryBuffer.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/OffHeapMemoryBuffer.java
@@ -21,7 +21,7 @@ package org.apache.directmemory.memory;
 
 import java.util.Date;
 
-public interface OffHeapMemoryBuffer
+public interface OffHeapMemoryBuffer<T>
 {
 
     /**
@@ -44,7 +44,7 @@ public interface OffHeapMemoryBuffer
      * @param payload : the data to store
      * @return the pointer where the data is stored, null in case of failure
      */
-    public Pointer store( byte[] payload );
+    public Pointer<T> store( byte[] payload );
 
     /**
      * Same as {@link #store(byte[])}, with an absolute expiration date
@@ -52,7 +52,7 @@ public interface OffHeapMemoryBuffer
      * @param expires : an absolute expiration date
      * @return the pointer where the data is stored, null in case of failure
      */
-    public Pointer store( byte[] payload, Date expires );
+    public Pointer<T> store( byte[] payload, Date expires );
 
     /**
      * Same as {@link #store(byte[])}, with an relative expiration delta
@@ -60,21 +60,21 @@ public interface OffHeapMemoryBuffer
      * @param expiresIn : a relative expiration delta
      * @return the pointer where the data is stored, null in case of failure
      */
-    public Pointer store( byte[] payload, long expiresIn );
+    public Pointer<T> store( byte[] payload, long expiresIn );
 
     /**
      * Return previously stored data associated to the given pointer
      * @param pointer : presiously allocated pointer
      * @return previously stored data
      */
-    public byte[] retrieve( Pointer pointer );
+    public byte[] retrieve( Pointer<T> pointer );
 
     /**
      * Release previously allocated memory
      * @param pointer2free : the pointer to free
      * @return the newly freed space
      */
-    public int free( Pointer pointer2free );
+    public int free( Pointer<T> pointer2free );
 
     /**
      * Completely empty the buffer
@@ -110,15 +110,15 @@ public interface OffHeapMemoryBuffer
      * @param payload : the data to update
      * @return the update pointer. It may be a new pointer.
      */
-    public Pointer update( Pointer pointer, byte[] payload );
+    public Pointer<T> update( Pointer<T> pointer, byte[] payload );
 
     /**
      * Allocate requested size and return a pointer and a ByteBuffer
-     * 
+     *
      * @param size
      * @param expiresIn
      * @param expires
      * @return
      */
-    public Pointer allocate( int size, long expiresIn, long expires );
+    public <V extends T> Pointer<T> allocate( Class<V> type, int size, long expiresIn, long expires );
 }

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/Pointer.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/Pointer.java
@@ -24,7 +24,7 @@ import static java.lang.String.format;
 
 import java.nio.ByteBuffer;
 
-public class Pointer
+public class Pointer<T>
 {
     public int start;
 
@@ -44,7 +44,7 @@ public class Pointer
 
     public int bufferNumber;
 
-    public Class<? extends Object> clazz;
+    public Class<? extends T> clazz;
 
     public ByteBuffer directBuffer = null;
 

--- a/directmemory-cache/src/main/java/org/apache/directmemory/memory/RoundRobinAllocationPolicy.java
+++ b/directmemory-cache/src/main/java/org/apache/directmemory/memory/RoundRobinAllocationPolicy.java
@@ -29,15 +29,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author bperroud
  */
-public class RoundRobinAllocationPolicy
-    implements AllocationPolicy
+public class RoundRobinAllocationPolicy<T>
+    implements AllocationPolicy<T>
 {
 
     // Increment the counter and get the value. Need to start at -1 to have 0'index at first call.
     private static final int BUFFERS_INDEX_INITIAL_VALUE = -1;
 
     // All the buffers to allocate
-    private List<OffHeapMemoryBuffer> buffers;
+    private List<OffHeapMemoryBuffer<T>> buffers;
 
     // Cyclic counter
     private AtomicInteger buffersIndexCounter = new AtomicInteger( BUFFERS_INDEX_INITIAL_VALUE );
@@ -54,13 +54,13 @@ public class RoundRobinAllocationPolicy
     }
 
     @Override
-    public void init( List<OffHeapMemoryBuffer> buffers )
+    public void init( List<OffHeapMemoryBuffer<T>> buffers )
     {
         this.buffers = buffers;
     }
 
     @Override
-    public OffHeapMemoryBuffer getActiveBuffer( OffHeapMemoryBuffer previouslyAllocatedBuffer, int allocationNumber )
+    public OffHeapMemoryBuffer<T> getActiveBuffer( OffHeapMemoryBuffer<T> previouslyAllocatedBuffer, int allocationNumber )
     {
         // If current allocation is more than the limit, return a null buffer.
         if ( allocationNumber > maxAllocations )
@@ -71,7 +71,7 @@ public class RoundRobinAllocationPolicy
         // Thread safely increment and get the next buffer's index
         int i = incrementAndGetBufferIndex();
 
-        final OffHeapMemoryBuffer buffer = buffers.get( i );
+        final OffHeapMemoryBuffer<T> buffer = buffers.get( i );
 
         return buffer;
     }

--- a/directmemory-cache/src/test/java/org/apache/directmemory/cache/CacheConcurrentTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/cache/CacheConcurrentTest.java
@@ -98,7 +98,7 @@ public class CacheConcurrentTest
 
     private void get( String key )
     {
-        Pointer p = Cache.getPointer( key );
+        Pointer<Object> p = Cache.getPointer( key );
         @SuppressWarnings( "unused" ) byte[] check = Cache.retrieveByteArray( key );
         read.incrementAndGet();
         if ( p != null )
@@ -252,6 +252,6 @@ public class CacheConcurrentTest
     }
 
 }
-	
-	
+
+
 

--- a/directmemory-cache/src/test/java/org/apache/directmemory/cache/CacheLightConcurrentTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/cache/CacheLightConcurrentTest.java
@@ -108,7 +108,7 @@ public class CacheLightConcurrentTest
 
     private void getAndRetrieve( String key )
     {
-        Pointer p = Cache.getPointer( key );
+        Pointer<Object> p = Cache.getPointer( key );
         @SuppressWarnings( "unused" ) byte[] check = Cache.retrieveByteArray( key );
         read.incrementAndGet();
         if ( p != null )

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/AbstractOffHeapMemoryBufferTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/AbstractOffHeapMemoryBufferTest.java
@@ -40,9 +40,9 @@ public abstract class AbstractOffHeapMemoryBufferTest
     protected static final int SMALL_PAYLOAD_LENGTH = 4;
     protected static final byte[] SMALL_PAYLOAD = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
 
-    
-    protected abstract OffHeapMemoryBuffer instanciateOffHeapMemoryBuffer( int bufferSize );
-    
+
+    protected abstract OffHeapMemoryBuffer<Object> instanciateOffHeapMemoryBuffer( int bufferSize );
+
     /**
      * Test pointers allocation, when buffer size is not aligned with the size of stored objects.
      * Null {@link Pointer} should be returned to allow {@link MemoryManagerService} to go to next step with allocation policy.
@@ -55,18 +55,18 @@ public abstract class AbstractOffHeapMemoryBufferTest
 
         final int BUFFER_SIZE = SMALL_PAYLOAD_LENGTH + 1;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
-        Pointer pointer1 = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+        Pointer<Object> pointer1 = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
         Assert.assertNotNull( pointer1 );
         Assert.assertFalse( pointer1.free );
         Assert.assertNull( pointer1.directBuffer );
 
-        Pointer pointer2 = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+        Pointer<Object> pointer2 = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
         Assert.assertNull( pointer2 );
 
     }
-    
+
 
     /**
      * Ensure no byte is leaking when allocating several objects.
@@ -79,16 +79,16 @@ public abstract class AbstractOffHeapMemoryBufferTest
 
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
-        
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
-        Pointer pointerNull = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+        Pointer<Object> pointerNull = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
         Assert.assertNull( pointerNull );
     }
 
@@ -104,12 +104,12 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 4;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
-        Pointer lastPointer = null;
+        Pointer<Object> lastPointer = null;
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
             lastPointer = pointer;
         }
@@ -120,7 +120,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
         Assert.assertNotNull( lastPointer );
         offHeapMemoryBuffer.free( lastPointer );
 
-        Pointer pointerNotNull = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+        Pointer<Object> pointerNotNull = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
         Assert.assertNotNull( pointerNotNull );
 
         // Buffer again fully used.
@@ -129,7 +129,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
     }
 
     /**
-     * Completely fill the buffer, free some pointer, reallocated the freed space, clear the buffer. The entire space should be  
+     * Completely fill the buffer, free some pointer, reallocated the freed space, clear the buffer. The entire space should be
      */
     @Test
     public void testFullFillAndFreeAndClearBuffer()
@@ -138,31 +138,31 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
-        Pointer pointerFull = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointerFull = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( pointerFull );
         offHeapMemoryBuffer.free( pointerFull );
 
         final int size1 = R.nextInt( BUFFER_SIZE / 2 ) + 1;
-        Pointer pointer1 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size1 ) );
+        Pointer<Object> pointer1 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size1 ) );
         Assert.assertNotNull( "Cannot store " + size1 + " bytes", pointer1 );
 
         final int size2 = R.nextInt( ( BUFFER_SIZE - size1 ) / 2 ) + 1;
-        Pointer pointer2 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size2 ) );
+        Pointer<Object> pointer2 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size2 ) );
         Assert.assertNotNull( "Cannot store " + size2 + " bytes", pointer2 );
 
         final int size3 = R.nextInt( ( BUFFER_SIZE - size1 - size2 ) / 2 ) + 1;
-        Pointer pointer3 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size3 ) );
+        Pointer<Object> pointer3 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size3 ) );
         Assert.assertNotNull( "Cannot store " + size3 + " bytes", pointer3 );
 
         final int size4 = BUFFER_SIZE - size1 - size2 - size3;
-        Pointer pointer4 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size4 ) );
+        Pointer<Object> pointer4 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( size4 ) );
         Assert.assertNotNull( "Cannot store " + size4 + " bytes", pointer4 );
 
         offHeapMemoryBuffer.free( pointer1 );
         Assert.assertTrue( pointer1.free );
-        
+
         offHeapMemoryBuffer.free( pointer3 );
 
         offHeapMemoryBuffer.free( pointer4 );
@@ -172,13 +172,13 @@ public abstract class AbstractOffHeapMemoryBufferTest
         Assert.assertEquals( 0, offHeapMemoryBuffer.used() );
 
         // As all pointers have been freeed, we should be able to reallocate the whole buffer
-        Pointer pointer6 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer6 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer6 );
 
         offHeapMemoryBuffer.clear();
 
         // As all pointers have been cleared, we should be able to reallocate the whole buffer
-        Pointer pointer7 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer7 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer7 );
 
         offHeapMemoryBuffer.clear();
@@ -186,14 +186,14 @@ public abstract class AbstractOffHeapMemoryBufferTest
         // As all pointers have been cleared, we should be able to reallocate the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
         offHeapMemoryBuffer.clear();
 
         // As all pointers have been cleared, we should be able to reallocate the whole buffer
-        Pointer pointer8 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer8 = offHeapMemoryBuffer.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer8 );
 
         offHeapMemoryBuffer.free( pointer8 );
@@ -201,7 +201,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
         // As all pointers have been cleared, we should be able to reallocate the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS * 10; i++ )
         {
-            Pointer pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
             offHeapMemoryBuffer.free( pointer );
         }
@@ -209,7 +209,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
         // After a clear occurs, pointers allocated before the clear should be set as "free"
         Assert.assertTrue( pointer6.free );
         Assert.assertTrue( pointer7.free );
-        
+
     }
 
     @Test
@@ -219,12 +219,12 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-            Pointer pointer = offHeapMemoryBuffer.store( payload );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( payload );
             Assert.assertNotNull( pointer );
             byte[] fetchedPayload = offHeapMemoryBuffer.retrieve( pointer );
             Assert.assertEquals( new String( payload ), new String( fetchedPayload ) );
@@ -239,7 +239,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-            Pointer pointer = offHeapMemoryBuffer.store( payload );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( payload );
             Assert.assertNotNull( pointer );
             byte[] fetchedPayload = offHeapMemoryBuffer.retrieve( pointer );
             Assert.assertEquals( new String( payload ), new String( fetchedPayload ) );
@@ -259,13 +259,13 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 100;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
-        List<Pointer> pointers = new ArrayList<Pointer>( NUMBER_OF_OBJECTS );
+        List<Pointer<Object>> pointers = new ArrayList<Pointer<Object>>( NUMBER_OF_OBJECTS );
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-            Pointer pointer = offHeapMemoryBuffer.store( payload );
+            Pointer<Object> pointer = offHeapMemoryBuffer.store( payload );
             Assert.assertNotNull( pointer );
             pointers.add( pointer );
             byte[] fetchedPayload = offHeapMemoryBuffer.retrieve( pointer );
@@ -275,35 +275,35 @@ public abstract class AbstractOffHeapMemoryBufferTest
         // Free 1/4 of the pointers, from 1/4 of the address space to 1/2
         for ( int i = NUMBER_OF_OBJECTS / 4; i < NUMBER_OF_OBJECTS / 2; i++ )
         {
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             offHeapMemoryBuffer.free( pointer );
         }
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH bytes
-        Pointer pointer1 = offHeapMemoryBuffer.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
+        Pointer<Object> pointer1 = offHeapMemoryBuffer.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
         Assert.assertNotNull( pointer1 );
 
         int pointerToSkip = NUMBER_OF_OBJECTS / 2 + NUMBER_OF_OBJECTS / 10;
         for ( int i = NUMBER_OF_OBJECTS / 2; i < NUMBER_OF_OBJECTS * 3 / 4; i++ )
         {
-            // skip one pointer 
+            // skip one pointer
             if ( i == pointerToSkip )
             {
                 continue;
             }
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             offHeapMemoryBuffer.free( pointer );
         }
 
         // Should NOT be able to allocate NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH bytes
-        Pointer pointer2 = offHeapMemoryBuffer.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
+        Pointer<Object> pointer2 = offHeapMemoryBuffer.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
         Assert.assertNull( pointer2 );
 
         // Freeing the previously skipped pointer should then merge the whole memory space
         offHeapMemoryBuffer.free( pointers.get( pointerToSkip ) );
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH bytes
-        Pointer pointer3 = offHeapMemoryBuffer.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
+        Pointer<Object> pointer3 = offHeapMemoryBuffer.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH, 0, 0 );
         Assert.assertNotNull( pointer3 );
 
         byte[] payload3 = MemoryTestUtils.generateRandomPayload( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD_LENGTH );
@@ -320,18 +320,18 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMergingMemoryBufferImpl offHeapLinkedMemoryBuffer = OffHeapMergingMemoryBufferImpl
+        final OffHeapMergingMemoryBufferImpl<Object> offHeapLinkedMemoryBuffer = OffHeapMergingMemoryBufferImpl
             .createNew( BUFFER_SIZE );
 
         byte[] payload1 = MemoryTestUtils.generateRandomPayload( 2 * SMALL_PAYLOAD_LENGTH );
-        Pointer pointer1 = offHeapLinkedMemoryBuffer.store( payload1 );
+        Pointer<Object> pointer1 = offHeapLinkedMemoryBuffer.store( payload1 );
         Assert.assertNotNull( pointer1 );
 
         byte[] fetchedPayload1 = offHeapLinkedMemoryBuffer.retrieve( pointer1 );
         Assert.assertEquals( new String( payload1 ), new String( fetchedPayload1 ) );
 
         byte[] payload2 = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-        Pointer pointer2 = offHeapLinkedMemoryBuffer.store( payload2 );
+        Pointer<Object> pointer2 = offHeapLinkedMemoryBuffer.store( payload2 );
         Assert.assertNotNull( pointer2 );
 
         byte[] fetchedPayload2 = offHeapLinkedMemoryBuffer.retrieve( pointer2 );
@@ -342,7 +342,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
         offHeapLinkedMemoryBuffer.free( pointer1 );
 
         byte[] payload3 = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-        Pointer pointer3 = offHeapLinkedMemoryBuffer.store( payload3 );
+        Pointer<Object> pointer3 = offHeapLinkedMemoryBuffer.store( payload3 );
         Assert.assertNotNull( pointer3 );
 
         byte[] fetchedPayload3 = offHeapLinkedMemoryBuffer.retrieve( pointer3 );
@@ -357,23 +357,23 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 1;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
         final byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
 
-        final Pointer pointer = offHeapMemoryBuffer.store( payload );
+        final Pointer<Object> pointer = offHeapMemoryBuffer.store( payload );
         Assert.assertNotNull( pointer );
         Assert.assertEquals( new String( payload ), new String( offHeapMemoryBuffer.retrieve( pointer ) ) );
 
         final byte[] otherPayload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH );
-        final Pointer otherPointer = offHeapMemoryBuffer.update( pointer, otherPayload );
+        final Pointer<Object> otherPointer = offHeapMemoryBuffer.update( pointer, otherPayload );
         Assert.assertNotNull( otherPointer );
         Assert.assertEquals( pointer.start, otherPointer.start );
         Assert.assertEquals( pointer.end, otherPointer.end );
         Assert.assertEquals( new String( otherPayload ), new String( offHeapMemoryBuffer.retrieve( otherPointer ) ) );
 
         final byte[] evenAnotherPayload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD_LENGTH / 2 );
-        final Pointer evenAnotherPointer = offHeapMemoryBuffer.update( pointer, evenAnotherPayload );
+        final Pointer<Object> evenAnotherPointer = offHeapMemoryBuffer.update( pointer, evenAnotherPayload );
         Assert.assertNotNull( evenAnotherPointer );
         Assert.assertEquals( pointer.start, evenAnotherPointer.start );
         Assert.assertEquals( pointer.end, evenAnotherPointer.end );
@@ -382,8 +382,8 @@ public abstract class AbstractOffHeapMemoryBufferTest
             .startsWith( new String( evenAnotherPayload ) ) );
 
     }
-    
-    
+
+
     @Test
     public void testAllocate()
     {
@@ -391,28 +391,28 @@ public abstract class AbstractOffHeapMemoryBufferTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD_LENGTH;
 
-        final OffHeapMemoryBuffer offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
+        final OffHeapMemoryBuffer<Object> offHeapMemoryBuffer = instanciateOffHeapMemoryBuffer( BUFFER_SIZE );
 
         final byte[] payload1 = MemoryTestUtils.generateRandomPayload( 8 * SMALL_PAYLOAD_LENGTH );
-        final Pointer pointer1 = offHeapMemoryBuffer.store( payload1 );
+        final Pointer<Object> pointer1 = offHeapMemoryBuffer.store( payload1 );
         Assert.assertNotNull( pointer1 );
         Assert.assertEquals( new String( payload1 ), new String( offHeapMemoryBuffer.retrieve( pointer1 ) ) );
 
         final byte[] payload2 = MemoryTestUtils.generateRandomPayload( 2 * SMALL_PAYLOAD_LENGTH );
-        final Pointer pointer2 = offHeapMemoryBuffer.store( payload2 );
+        final Pointer<Object> pointer2 = offHeapMemoryBuffer.store( payload2 );
         Assert.assertNotNull( pointer2 );
         Assert.assertEquals( new String( payload2 ), new String( offHeapMemoryBuffer.retrieve( pointer2 ) ) );
 
         offHeapMemoryBuffer.free( pointer1 );
-        
+
         final byte[] payload3 = MemoryTestUtils.generateRandomPayload( 2 * SMALL_PAYLOAD_LENGTH );
-        final Pointer pointer3 = offHeapMemoryBuffer.store( payload3 );
+        final Pointer<Object> pointer3 = offHeapMemoryBuffer.store( payload3 );
         Assert.assertNotNull( pointer3 );
         Assert.assertEquals( new String( payload3 ), new String( offHeapMemoryBuffer.retrieve( pointer3 ) ) );
 
         final int size1 = 4 * SMALL_PAYLOAD_LENGTH;
         final byte[] allocatedPayload1 = MemoryTestUtils.generateRandomPayload( size1 );
-        final Pointer allocatedPointer1 = offHeapMemoryBuffer.allocate( allocatedPayload1.length, -1, -1 );
+        final Pointer<Object> allocatedPointer1 = offHeapMemoryBuffer.allocate( Object.class, allocatedPayload1.length, -1, -1 );
         Assert.assertNotNull( allocatedPointer1 );
         final ByteBuffer buffer1 = allocatedPointer1.directBuffer;
         Assert.assertNotNull( buffer1 );
@@ -424,7 +424,7 @@ public abstract class AbstractOffHeapMemoryBufferTest
 
         final int size2 = 2 * SMALL_PAYLOAD_LENGTH;
         final byte[] allocatedPayload2 = MemoryTestUtils.generateRandomPayload( size2 );
-        final Pointer allocatedPointer2 = offHeapMemoryBuffer.allocate( allocatedPayload2.length, -1, -1 );
+        final Pointer<Object> allocatedPointer2 = offHeapMemoryBuffer.allocate( Object.class, allocatedPayload2.length, -1, -1 );
         Assert.assertNotNull( allocatedPointer2 );
         final ByteBuffer buffer2 = allocatedPointer2.directBuffer;
         Assert.assertNotNull( buffer2 );
@@ -433,11 +433,11 @@ public abstract class AbstractOffHeapMemoryBufferTest
         buffer2.put( allocatedPayload2 );
         Assert.assertEquals( new String( allocatedPayload2 ), new String( offHeapMemoryBuffer.retrieve( allocatedPointer2 ) ) );
 
-        
+
         // Ensure the new allocation has not overwritten other data
         Assert.assertEquals( new String( payload2 ), new String( offHeapMemoryBuffer.retrieve( pointer2 ) ) );
         Assert.assertEquals( new String( payload3 ), new String( offHeapMemoryBuffer.retrieve( pointer3 ) ) );
 
     }
-    
+
 }

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/BaseTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/BaseTest.java
@@ -50,7 +50,7 @@ public class BaseTest
     @Test
     public void smokeTest()
     {
-        OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 1 * 1024 * 1024 );
+        OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 1 * 1024 * 1024 );
         logger.info( "buffer size=" + mem.capacity() );
         assertNotNull( mem );
 
@@ -60,7 +60,7 @@ public class BaseTest
 
         logger.info( "size=" + size );
 
-        Pointer p = mem.store( new byte[size] );
+        Pointer<Object> p = mem.store( new byte[size] );
         assertNotNull( p );
         assertEquals( size, p.end );
         assertEquals( size, mem.used() );
@@ -117,7 +117,7 @@ public class BaseTest
     @Test
     public void aFewEntriesWithRead()
     {
-        OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 100 * 1024 * 1024 );
+        OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 100 * 1024 * 1024 );
         logger.info( "total capacity=" + Ram.inMb( mem.capacity() ) );
         assertNotNull( mem );
         int howMany = 10000;
@@ -127,7 +127,7 @@ public class BaseTest
         for ( int i = 0; i < howMany; i++ )
         {
             final byte[] payload = ( test + " - " + i ).getBytes();
-            Pointer p = mem.store( payload );
+            Pointer<Object> p = mem.store( payload );
             final byte[] check = mem.retrieve( p );
             assertNotNull( check );
             assertEquals( test + " - " + i, new String( check ) );
@@ -149,18 +149,18 @@ public class BaseTest
     @Test
     public void aFewEntriesWithCheck()
     {
-        OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 10 * 1024 * 1024 );
+        OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 10 * 1024 * 1024 );
         logger.info( "total capacity=" + Ram.inMb( mem.capacity() ) );
         assertNotNull( mem );
         int howMany = 10;
         logger.info( "payload size is variable" );
         logger.info( "entries=" + howMany );
         String test = "this is a nicely crafted test";
-        Pointer lastP = null;
+        Pointer<Object> lastP = null;
         for ( int i = 0; i < howMany; i++ )
         {
             byte[] payload = ( test + " - " + i ).getBytes();
-            Pointer p = mem.store( payload );
+            Pointer<Object> p = mem.store( payload );
             logger.info( "p.start=" + p.start );
             logger.info( "p.end=" + p.end );
             if ( lastP != null )
@@ -179,7 +179,7 @@ public class BaseTest
     public void checkExpiration()
         throws InterruptedException
     {
-        OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 10 * 1024 * 1024 );
+        OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 10 * 1024 * 1024 );
         assertNotNull( mem );
         int size = 400;
         int howMany = 5000;

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/Concurrent2Test.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/Concurrent2Test.java
@@ -63,7 +63,7 @@ public class Concurrent2Test
 
     private static AtomicInteger read = new AtomicInteger();
 
-    public static ConcurrentMap<String, Pointer> map =
+    public static ConcurrentMap<String, Pointer<Object>> map =
         new MapMaker().concurrencyLevel( 4 ).initialCapacity( 100000 ).makeMap();
 
 
@@ -80,7 +80,7 @@ public class Concurrent2Test
     public void retrieveCatchThemAll()
     {
         String key = "test-" + ( rndGen.nextInt( entries ) + 1 );
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -107,7 +107,7 @@ public class Concurrent2Test
     public void retrieveCatchHalfOfThem()
     {
         String key = "test-" + ( rndGen.nextInt( entries * 2 ) + 1 );
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -179,7 +179,7 @@ public class Concurrent2Test
 
     private void get( String key )
     {
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -204,7 +204,7 @@ public class Concurrent2Test
 
     private static Logger logger = LoggerFactory.getLogger( Concurrent2Test.class );
 
-    private static void dump( OffHeapMemoryBuffer mem )
+    private static void dump( OffHeapMemoryBuffer<Object> mem )
     {
         logger.info( "off-heap - buffer: " + mem.getBufferNumber() );
         logger.info( "off-heap - allocated: " + Ram.inMb( mem.capacity() ) );
@@ -225,7 +225,7 @@ public class Concurrent2Test
     public static void dump()
     {
 
-        for ( OffHeapMemoryBuffer mem : MemoryManager.getBuffers() )
+        for ( OffHeapMemoryBuffer<Object> mem : MemoryManager.getBuffers() )
         {
             dump( mem );
         }
@@ -243,6 +243,3 @@ public class Concurrent2Test
     }
 
 }
-	
-	
-

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/Concurrent3Test.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/Concurrent3Test.java
@@ -63,7 +63,7 @@ public class Concurrent3Test
 
     private static AtomicInteger disposals = new AtomicInteger();
 
-    public static ConcurrentMap<String, Pointer> map =
+    public static ConcurrentMap<String, Pointer<Object>> map =
         new MapMaker().concurrencyLevel( 4 ).initialCapacity( 100000 ).makeMap();
 
 
@@ -101,7 +101,7 @@ public class Concurrent3Test
 
     private void get( String key )
     {
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -226,7 +226,7 @@ public class Concurrent3Test
 
     private static Logger logger = LoggerFactory.getLogger( Concurrent3Test.class );
 
-    private static void dump( OffHeapMemoryBuffer mem )
+    private static void dump( OffHeapMemoryBuffer<Object> mem )
     {
         logger.info( "off-heap - buffer: " + mem.getBufferNumber() );
         logger.info( "off-heap - allocated: " + Ram.inMb( mem.capacity() ) );
@@ -247,7 +247,7 @@ public class Concurrent3Test
     public static void dump()
     {
 
-        for ( OffHeapMemoryBuffer mem : MemoryManager.getBuffers() )
+        for ( OffHeapMemoryBuffer<Object> mem : MemoryManager.getBuffers() )
         {
             dump( mem );
         }
@@ -266,6 +266,6 @@ public class Concurrent3Test
     }
 
 }
-	
-	
+
+
 

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/ConcurrentTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/ConcurrentTest.java
@@ -64,9 +64,9 @@ public class ConcurrentTest
 
     private static AtomicInteger read = new AtomicInteger();
 
-    public static OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 512 * 1024 * 1024 );
+    public static OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 512 * 1024 * 1024 );
 
-    public static ConcurrentMap<String, Pointer> map =
+    public static ConcurrentMap<String, Pointer<Object>> map =
         new MapMaker().concurrencyLevel( 4 ).initialCapacity( 100000 ).makeMap();
 
 
@@ -83,7 +83,7 @@ public class ConcurrentTest
     public void retrieveCatchThemAll()
     {
         String key = "test-" + ( rndGen.nextInt( entries ) + 1 );
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -110,7 +110,7 @@ public class ConcurrentTest
     public void retrieveCatchHalfOfThem()
     {
         String key = "test-" + ( rndGen.nextInt( entries * 2 ) + 1 );
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -182,7 +182,7 @@ public class ConcurrentTest
 
     private void get( String key )
     {
-        Pointer p = map.get( key );
+        Pointer<Object> p = map.get( key );
         read.incrementAndGet();
         if ( p != null )
         {
@@ -229,6 +229,6 @@ public class ConcurrentTest
     }
 
 }
-	
-	
+
+
 

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/MallocTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/MallocTest.java
@@ -68,7 +68,7 @@ public class MallocTest
         logger.info( "************************************************" );
     }
 
-    OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( 512 * 1024 * 1024 );
+    OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( 512 * 1024 * 1024 );
 
     @Test
     public void oneMillionEntries()
@@ -144,7 +144,7 @@ public class MallocTest
     public void withMap()
     {
 
-        ConcurrentMap<Long, Pointer> map = new MapMaker().concurrencyLevel( 4 ).initialCapacity( 500000 ).makeMap();
+        ConcurrentMap<Long, Pointer<Object>> map = new MapMaker().concurrencyLevel( 4 ).initialCapacity( 500000 ).makeMap();
 
         String str = "This is the string to store into the off-heap memory";
 
@@ -155,7 +155,7 @@ public class MallocTest
         logger.info( "adding " + howMany + " strings of " + size + " bytes..." );
         for ( long i = 0; i < howMany; i++ )
         {
-            Pointer p = mem.store( payload );
+            Pointer<Object> p = mem.store( payload );
             map.put( i, p );
         }
         logger.info( "...done" );
@@ -183,7 +183,7 @@ public class MallocTest
         byte[] payload = test.getBytes();
         for ( int i = 0; i < howMany; i++ )
         {
-            Pointer p = mem.store( payload );
+            Pointer<Object> p = mem.store( payload );
             byte[] check = mem.retrieve( p );
             assertNotNull( check );
             assertEquals( test, new String( check ) );
@@ -192,6 +192,3 @@ public class MallocTest
         logger.info( "total used=" + Ram.inMb( mem.used() ) );
     }
 }
-	
-	
-

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplTest.java
@@ -35,9 +35,9 @@ public class MemoryManagerServiceImplTest
 
     protected static final byte[] SMALL_PAYLOAD = "ABCD".getBytes();
 
-    protected MemoryManagerService getMemoryManagerService()
+    protected MemoryManagerService<Object> getMemoryManagerService()
     {
-        return new MemoryManagerServiceImpl();
+        return new MemoryManagerServiceImpl<Object>();
     }
 
     @Test
@@ -50,14 +50,14 @@ public class MemoryManagerServiceImplTest
 
         final int BUFFER_SIZE = 5;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        Pointer pointer1 = memoryManagerService.store( SMALL_PAYLOAD );
+        Pointer<Object> pointer1 = memoryManagerService.store( SMALL_PAYLOAD );
         Assert.assertNotNull( pointer1 );
 
-        Pointer pointer2 = memoryManagerService.store( SMALL_PAYLOAD );
+        Pointer<Object> pointer2 = memoryManagerService.store( SMALL_PAYLOAD );
         Assert.assertNull( pointer2 );
 
     }
@@ -71,17 +71,17 @@ public class MemoryManagerServiceImplTest
 
         final int NUMBER_OF_OBJECTS = 4;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( NUMBER_OF_OBJECTS, SMALL_PAYLOAD.length );
 
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
-        Pointer pointerNull = memoryManagerService.store( SMALL_PAYLOAD );
+        Pointer<Object> pointerNull = memoryManagerService.store( SMALL_PAYLOAD );
         Assert.assertNull( pointerNull );
     }
 
@@ -94,16 +94,16 @@ public class MemoryManagerServiceImplTest
 
         final int NUMBER_OF_OBJECTS = 10;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
         memoryManagerService.init( 1, NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length );
 
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
-        Pointer pointerNull = memoryManagerService.store( SMALL_PAYLOAD );
+        Pointer<Object> pointerNull = memoryManagerService.store( SMALL_PAYLOAD );
         Assert.assertNull( pointerNull );
     }
 
@@ -117,14 +117,14 @@ public class MemoryManagerServiceImplTest
         final int NUMBER_OF_OBJECTS = 4;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        Pointer lastPointer = null;
+        Pointer<Object> lastPointer = null;
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
             lastPointer = pointer;
         }
@@ -135,7 +135,7 @@ public class MemoryManagerServiceImplTest
         Assert.assertNotNull( lastPointer );
         memoryManagerService.free( lastPointer );
 
-        Pointer pointerNotNull = memoryManagerService.store( SMALL_PAYLOAD );
+        Pointer<Object> pointerNotNull = memoryManagerService.store( SMALL_PAYLOAD );
         Assert.assertNotNull( pointerNotNull );
 
         // Buffer again fully used.
@@ -150,14 +150,14 @@ public class MemoryManagerServiceImplTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD.length );
-            Pointer pointer = memoryManagerService.store( payload );
+            Pointer<Object> pointer = memoryManagerService.store( payload );
             Assert.assertNotNull( pointer );
             byte[] fetchedPayload = memoryManagerService.retrieve( pointer );
             Assert.assertEquals( new String( payload ), new String( fetchedPayload ) );
@@ -172,7 +172,7 @@ public class MemoryManagerServiceImplTest
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD.length );
-            Pointer pointer = memoryManagerService.store( payload );
+            Pointer<Object> pointer = memoryManagerService.store( payload );
             Assert.assertNotNull( pointer );
             byte[] fetchedPayload = memoryManagerService.retrieve( pointer );
             Assert.assertEquals( new String( payload ), new String( fetchedPayload ) );
@@ -185,7 +185,7 @@ public class MemoryManagerServiceImplTest
 
         memoryManagerService.clear();
 
-        Pointer pointer = null;
+        Pointer<Object> pointer = null;
         do
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( R.nextInt( BUFFER_SIZE / 4 + 1 ) );

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest.java
@@ -37,19 +37,19 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
 {
 
     @Override
-    protected MemoryManagerService getMemoryManagerService()
+    protected MemoryManagerService<Object> getMemoryManagerService()
     {
         // Initialize MemoryManagerService with OffHeapMergingMemoryBufferImpl and AllocationPolicy
-        final MemoryManagerServiceWithAllocationPolicyImpl mms = new MemoryManagerServiceWithAllocationPolicyImpl()
+        final MemoryManagerServiceWithAllocationPolicyImpl<Object> mms = new MemoryManagerServiceWithAllocationPolicyImpl<Object>()
         {
             @Override
-            protected OffHeapMemoryBuffer instanciateOffHeapMemoryBuffer( int size, int bufferNumber )
+            protected OffHeapMemoryBuffer<Object> instanciateOffHeapMemoryBuffer( int size, int bufferNumber )
             {
                 return OffHeapMergingMemoryBufferImpl.createNew( size, bufferNumber );
             }
         };
-        
-        mms.setAllocationPolicy( new RoundRobinAllocationPolicy() );
+
+        mms.setAllocationPolicy( new RoundRobinAllocationPolicy<Object>() );
         return mms;
     }
 
@@ -60,28 +60,28 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        Pointer pointerFull = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointerFull = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( pointerFull );
         memoryManagerService.free( pointerFull );
 
         final int size1 = R.nextInt( BUFFER_SIZE / 2 ) + 1;
-        Pointer pointer1 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size1 ) );
+        Pointer<Object> pointer1 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size1 ) );
         Assert.assertNotNull( "Cannot store " + size1 + " bytes", pointer1 );
 
         final int size2 = R.nextInt( ( BUFFER_SIZE - size1 ) / 2 ) + 1;
-        Pointer pointer2 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size2 ) );
+        Pointer<Object> pointer2 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size2 ) );
         Assert.assertNotNull( "Cannot store " + size2 + " bytes", pointer2 );
 
         final int size3 = R.nextInt( ( BUFFER_SIZE - size1 - size2 ) / 2 ) + 1;
-        Pointer pointer3 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size3 ) );
+        Pointer<Object> pointer3 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size3 ) );
         Assert.assertNotNull( "Cannot store " + size3 + " bytes", pointer3 );
 
         final int size4 = BUFFER_SIZE - size1 - size2 - size3;
-        Pointer pointer4 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size4 ) );
+        Pointer<Object> pointer4 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size4 ) );
         Assert.assertNotNull( "Cannot store " + size4 + " bytes", pointer4 );
 
         memoryManagerService.free( pointer1 );
@@ -96,14 +96,14 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
 
         // As all pointers have been freeed, we should be able to reallocate the
         // whole buffer
-        Pointer pointer6 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer6 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer6 );
 
         memoryManagerService.clear();
 
         // As all pointers have been cleared, we should be able to reallocate
         // the whole buffer
-        Pointer pointer7 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer7 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer7 );
 
         memoryManagerService.clear();
@@ -112,7 +112,7 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
         // the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
@@ -120,7 +120,7 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
 
         // As all pointers have been cleared, we should be able to reallocate
         // the whole buffer
-        Pointer pointer8 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer8 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer8 );
 
         memoryManagerService.free( pointer8 );
@@ -129,7 +129,7 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
         // the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS * 10; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
             memoryManagerService.free( pointer );
         }
@@ -143,15 +143,15 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
         final int NUMBER_OF_OBJECTS = 100;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        List<Pointer> pointers = new ArrayList<Pointer>( NUMBER_OF_OBJECTS );
+        List<Pointer<Object>> pointers = new ArrayList<Pointer<Object>>( NUMBER_OF_OBJECTS );
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD.length );
-            Pointer pointer = memoryManagerService.store( payload );
+            Pointer<Object> pointer = memoryManagerService.store( payload );
             Assert.assertNotNull( pointer );
             pointers.add( pointer );
             byte[] fetchedPayload = memoryManagerService.retrieve( pointer );
@@ -161,13 +161,13 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
         // Free 1/4 of the pointers, from 1/4 of the address space to 1/2
         for ( int i = NUMBER_OF_OBJECTS / 4; i < NUMBER_OF_OBJECTS / 2; i++ )
         {
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             memoryManagerService.free( pointer );
         }
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer1 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer1 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNotNull( "Cannot store " + ( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length ) + " bytes", pointer1 );
 
         int pointerToSkip = NUMBER_OF_OBJECTS / 2 + NUMBER_OF_OBJECTS / 10;
@@ -178,13 +178,13 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
             {
                 continue;
             }
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             memoryManagerService.free( pointer );
         }
 
         // Should NOT be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer2 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer2 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNull( pointer2 );
 
         // Freeing the previously skipped pointer should then merge the whole
@@ -193,7 +193,7 @@ public class MemoryManagerServiceImplWithMerginOHMBAndAllocationPolicyTest
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer3 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer3 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNotNull( pointer3 );
 
         byte[] payload3 = MemoryTestUtils.generateRandomPayload( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length );

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplWithMerginOHMBTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerServiceImplWithMerginOHMBTest.java
@@ -36,12 +36,12 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
 {
 
     @Override
-    protected MemoryManagerService getMemoryManagerService()
+    protected MemoryManagerService<Object> getMemoryManagerService()
     {
-        return new MemoryManagerServiceImpl()
+        return new MemoryManagerServiceImpl<Object>()
         {
             @Override
-            protected OffHeapMemoryBuffer instanciateOffHeapMemoryBuffer( int size, int bufferNumber )
+            protected OffHeapMemoryBuffer<Object> instanciateOffHeapMemoryBuffer( int size, int bufferNumber )
             {
                 return OffHeapMergingMemoryBufferImpl.createNew( size, bufferNumber );
             }
@@ -55,28 +55,28 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
         final int NUMBER_OF_OBJECTS = 10;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        Pointer pointerFull = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointerFull = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( pointerFull );
         memoryManagerService.free( pointerFull );
 
         final int size1 = R.nextInt( BUFFER_SIZE / 2 ) + 1;
-        Pointer pointer1 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size1 ) );
+        Pointer<Object> pointer1 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size1 ) );
         Assert.assertNotNull( "Cannot store " + size1 + " bytes", pointer1 );
 
         final int size2 = R.nextInt( ( BUFFER_SIZE - size1 ) / 2 ) + 1;
-        Pointer pointer2 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size2 ) );
+        Pointer<Object> pointer2 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size2 ) );
         Assert.assertNotNull( "Cannot store " + size2 + " bytes", pointer2 );
 
         final int size3 = R.nextInt( ( BUFFER_SIZE - size1 - size2 ) / 2 ) + 1;
-        Pointer pointer3 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size3 ) );
+        Pointer<Object> pointer3 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size3 ) );
         Assert.assertNotNull( "Cannot store " + size3 + " bytes", pointer3 );
 
         final int size4 = BUFFER_SIZE - size1 - size2 - size3;
-        Pointer pointer4 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size4 ) );
+        Pointer<Object> pointer4 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( size4 ) );
         Assert.assertNotNull( "Cannot store " + size4 + " bytes", pointer4 );
 
         memoryManagerService.free( pointer1 );
@@ -91,14 +91,14 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
 
         // As all pointers have been freeed, we should be able to reallocate the
         // whole buffer
-        Pointer pointer6 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer6 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer6 );
 
         memoryManagerService.clear();
 
         // As all pointers have been cleared, we should be able to reallocate
         // the whole buffer
-        Pointer pointer7 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer7 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer7 );
 
         memoryManagerService.clear();
@@ -107,7 +107,7 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
         // the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
         }
 
@@ -115,7 +115,7 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
 
         // As all pointers have been cleared, we should be able to reallocate
         // the whole buffer
-        Pointer pointer8 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
+        Pointer<Object> pointer8 = memoryManagerService.store( MemoryTestUtils.generateRandomPayload( BUFFER_SIZE ) );
         Assert.assertNotNull( "Cannot store " + BUFFER_SIZE + " bytes", pointer8 );
 
         memoryManagerService.free( pointer8 );
@@ -124,7 +124,7 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
         // the whole buffer
         for ( int i = 0; i < NUMBER_OF_OBJECTS * 10; i++ )
         {
-            Pointer pointer = memoryManagerService.store( SMALL_PAYLOAD );
+            Pointer<Object> pointer = memoryManagerService.store( SMALL_PAYLOAD );
             Assert.assertNotNull( pointer );
             memoryManagerService.free( pointer );
         }
@@ -138,15 +138,15 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
         final int NUMBER_OF_OBJECTS = 100;
         final int BUFFER_SIZE = NUMBER_OF_OBJECTS * SMALL_PAYLOAD.length;
 
-        final MemoryManagerService memoryManagerService = getMemoryManagerService();
+        final MemoryManagerService<Object> memoryManagerService = getMemoryManagerService();
 
         memoryManagerService.init( 1, BUFFER_SIZE );
 
-        List<Pointer> pointers = new ArrayList<Pointer>( NUMBER_OF_OBJECTS );
+        List<Pointer<Object>> pointers = new ArrayList<Pointer<Object>>( NUMBER_OF_OBJECTS );
         for ( int i = 0; i < NUMBER_OF_OBJECTS; i++ )
         {
             byte[] payload = MemoryTestUtils.generateRandomPayload( SMALL_PAYLOAD.length );
-            Pointer pointer = memoryManagerService.store( payload );
+            Pointer<Object> pointer = memoryManagerService.store( payload );
             Assert.assertNotNull( pointer );
             pointers.add( pointer );
             byte[] fetchedPayload = memoryManagerService.retrieve( pointer );
@@ -156,13 +156,13 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
         // Free 1/4 of the pointers, from 1/4 of the address space to 1/2
         for ( int i = NUMBER_OF_OBJECTS / 4; i < NUMBER_OF_OBJECTS / 2; i++ )
         {
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             memoryManagerService.free( pointer );
         }
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer1 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer1 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNotNull( "Cannot store " + ( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length ) + " bytes", pointer1 );
 
         int pointerToSkip = NUMBER_OF_OBJECTS / 2 + NUMBER_OF_OBJECTS / 10;
@@ -173,13 +173,13 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
             {
                 continue;
             }
-            Pointer pointer = pointers.get( i );
+            Pointer<Object> pointer = pointers.get( i );
             memoryManagerService.free( pointer );
         }
 
         // Should NOT be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer2 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer2 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNull( pointer2 );
 
         // Freeing the previously skipped pointer should then merge the whole
@@ -188,7 +188,7 @@ public class MemoryManagerServiceImplWithMerginOHMBTest
 
         // Should be able to allocate NUMBER_OF_OBJECTS / 4 *
         // SMALL_PAYLOAD.length bytes
-        Pointer pointer3 = memoryManagerService.allocate( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
+        Pointer<Object> pointer3 = memoryManagerService.allocate( Object.class, NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length, 0, 0 );
         Assert.assertNotNull( pointer3 );
 
         byte[] payload3 = MemoryTestUtils.generateRandomPayload( NUMBER_OF_OBJECTS / 4 * SMALL_PAYLOAD.length );

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/MemoryManagerTest.java
@@ -55,7 +55,7 @@ public class MemoryManagerTest
         Random rnd = new Random();
         int size = rnd.nextInt( 10 ) * (int) MemoryManager.capacity() / 100;
         logger.info( "payload size=" + Ram.inKb( size ) );
-        Pointer p = MemoryManager.store( new byte[size] );
+        Pointer<Object> p = MemoryManager.store( new byte[size] );
         logger.info( "stored" );
         assertNotNull( p );
         //assertEquals(size,p.end);
@@ -78,7 +78,7 @@ public class MemoryManagerTest
 
         for ( int i = 0; i < howMany; i++ )
         {
-            Pointer p = MemoryManager.store( payload );
+            Pointer<Object> p = MemoryManager.store( payload );
             assertNotNull( p );
         }
 
@@ -89,9 +89,9 @@ public class MemoryManagerTest
     @Test
     public void readTest()
     {
-        for ( OffHeapMemoryBuffer buffer : MemoryManager.getBuffers() )
+        for ( OffHeapMemoryBuffer<Object> buffer : MemoryManager.getBuffers() )
         {
-            for ( Pointer ptr : ((OffHeapMemoryBufferImpl)buffer).getPointers() )
+            for ( Pointer<Object> ptr : ((OffHeapMemoryBufferImpl<Object>) buffer).getPointers() )
             {
                 if ( !ptr.free )
                 {

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/NIOTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/NIOTest.java
@@ -53,7 +53,7 @@ public class NIOTest
 
         for ( int i = 0; i < howMany; i++ )
         {
-            Pointer p = MemoryManager.store( payload );
+            Pointer<Object> p = MemoryManager.store( payload );
             assertNotNull( p );
         }
 
@@ -61,12 +61,12 @@ public class NIOTest
     }
 
     @Test
-    public void NIOTest()
+    public void nioTest()
     {
         Random rnd = new Random();
         int size = rnd.nextInt( 10 ) * (int) MemoryManager.capacity() / 100;
         logger.info( "payload size=" + Ram.inKb( size ) );
-        Pointer p = MemoryManager.allocate( size );
+        Pointer<Object> p = MemoryManager.allocate( size );
         ByteBuffer b = p.directBuffer;
         logger.info( "allocated" );
         assertNotNull( p );

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/OffHeapMemoryBufferTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/OffHeapMemoryBufferTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class OffHeapMemoryBufferTest extends AbstractOffHeapMemoryBufferTest
 {
 
-    protected OffHeapMemoryBuffer instanciateOffHeapMemoryBuffer( int bufferSize ) 
+    protected OffHeapMemoryBuffer<Object> instanciateOffHeapMemoryBuffer( int bufferSize )
     {
         return OffHeapMemoryBufferImpl.createNew( bufferSize );
     }
@@ -37,13 +37,13 @@ public class OffHeapMemoryBufferTest extends AbstractOffHeapMemoryBufferTest
     {
         // DIRECTMEMORY-40 : Pointers merging with adjacent free pointers when freeing.
     }
-    
+
     @Test
     public void testStoreAllocAndFree()
     {
         // DIRECTMEMORY-40 : Pointers merging with adjacent free pointers when freeing.
     }
-    
+
     @Test
     public void testUpdate()
     {

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/OffHeapMergingMemoryBufferTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/OffHeapMergingMemoryBufferTest.java
@@ -26,7 +26,7 @@ import org.apache.directmemory.memory.OffHeapMemoryBuffer;
 public class OffHeapMergingMemoryBufferTest extends AbstractOffHeapMemoryBufferTest
 {
 
-    protected OffHeapMemoryBuffer instanciateOffHeapMemoryBuffer( int bufferSize ) 
+    protected OffHeapMemoryBuffer<Object> instanciateOffHeapMemoryBuffer( int bufferSize )
     {
         return OffHeapMergingMemoryBufferImpl.createNew( bufferSize );
     }

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/RoundRobinAllocationPolicyTest.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/RoundRobinAllocationPolicyTest.java
@@ -41,22 +41,22 @@ public class RoundRobinAllocationPolicyTest
 
     private static final int NUMBER_OF_BUFFERS = 4;
 
-    List<OffHeapMemoryBuffer> buffers;
+    List<OffHeapMemoryBuffer<Object>> buffers;
 
-    RoundRobinAllocationPolicy allocationPolicy;
+    RoundRobinAllocationPolicy<Object> allocationPolicy;
 
     @Before
     public void initAllocationPolicy()
     {
 
-        buffers = new ArrayList<OffHeapMemoryBuffer>();
+        buffers = new ArrayList<OffHeapMemoryBuffer<Object>>();
 
         for ( int i = 0; i < NUMBER_OF_BUFFERS; i++ )
         {
             buffers.add( new DummyOffHeapMemoryBufferImpl() );
         }
 
-        allocationPolicy = new RoundRobinAllocationPolicy();
+        allocationPolicy = new RoundRobinAllocationPolicy<Object>();
         allocationPolicy.init( buffers );
     }
 
@@ -108,7 +108,7 @@ public class RoundRobinAllocationPolicyTest
      * Dummy {@link OffHeapMemoryBuffer} that do nothing.
      */
     private static class DummyOffHeapMemoryBufferImpl
-        implements OffHeapMemoryBuffer
+        implements OffHeapMemoryBuffer<Object>
     {
 
         @Override
@@ -130,31 +130,31 @@ public class RoundRobinAllocationPolicyTest
         }
 
         @Override
-        public Pointer store( byte[] payload )
+        public Pointer<Object> store( byte[] payload )
         {
             return null;
         }
 
         @Override
-        public Pointer store( byte[] payload, Date expires )
+        public Pointer<Object> store( byte[] payload, Date expires )
         {
             return null;
         }
 
         @Override
-        public Pointer store( byte[] payload, long expiresIn )
+        public Pointer<Object> store( byte[] payload, long expiresIn )
         {
             return null;
         }
 
         @Override
-        public byte[] retrieve( Pointer pointer )
+        public byte[] retrieve( Pointer<Object> pointer )
         {
             return null;
         }
 
         @Override
-        public int free( Pointer pointer2free )
+        public int free( Pointer<Object> pointer2free )
         {
             return 0;
         }
@@ -187,14 +187,15 @@ public class RoundRobinAllocationPolicyTest
         }
 
         @Override
-        public Pointer update( Pointer pointer, byte[] payload )
+        public Pointer<Object> update( Pointer<Object> pointer, byte[] payload )
         {
             return null;
         }
 
         @Override
-        public Pointer allocate( int size, long expiresIn, long expires )
+        public <V> Pointer<Object> allocate( Class<V> type, int size, long expiresIn, long expires )
         {
+            // TODO Auto-generated method stub
             return null;
         }
     }

--- a/directmemory-cache/src/test/java/org/apache/directmemory/memory/Starter.java
+++ b/directmemory-cache/src/test/java/org/apache/directmemory/memory/Starter.java
@@ -59,7 +59,7 @@ public class Starter
         starter.rawInsertMultipleBuffers( buffers, mb, entries );
     }
 
-    public void dump( OffHeapMemoryBuffer mem )
+    public void dump( OffHeapMemoryBuffer<Object> mem )
     {
         logger.info( "off-heap - buffer: " + mem.getBufferNumber() );
         logger.info( "off-heap - allocated: " + Ram.inMb( mem.capacity() ) );
@@ -72,7 +72,7 @@ public class Starter
 
     public void rawInsert( int megabytes, int howMany )
     {
-        OffHeapMemoryBuffer mem = OffHeapMemoryBufferImpl.createNew( megabytes * 1024 * 1024 );
+        OffHeapMemoryBuffer<Object> mem = OffHeapMemoryBufferImpl.createNew( megabytes * 1024 * 1024 );
         assertNotNull( mem );
         int size = mem.capacity() / ( howMany );
         size -= size / 100 * 1;
@@ -116,7 +116,7 @@ public class Starter
         logger.info( "...done in " + ( System.currentTimeMillis() - start ) + " msecs." );
         logger.info( "---------------------------------" );
 
-        for ( OffHeapMemoryBuffer buf : MemoryManager.getBuffers() )
+        for ( OffHeapMemoryBuffer<Object> buf : MemoryManager.getBuffers() )
         {
             dump( buf );
         }


### PR DESCRIPTION
This is my proposal to change the DM signature from <String, Object> to <K, V>.

It contains some signatures modification.

Please review!
